### PR TITLE
The Zdeg (Brho-Brho) method has been implemented in the code. The ene…

### DIFF
--- a/inc/Beam.hh
+++ b/inc/Beam.hh
@@ -40,6 +40,10 @@ public:
       fdelta[j] = sqrt(-1.);
       fbrho[j] = sqrt(-1.);
     }
+    for(unsigned short j=0;j<2;j++){
+      fzdeg[j] = sqrt(-1.);
+      fzdegc[j] = sqrt(-1.);
+    }
     ftargetpos.SetXYZ(0,0,-99999);
     fincdir.SetXYZ(0,0,-99999);
     foutdir.SetXYZ(0,0,-99999);
@@ -67,6 +71,16 @@ public:
     if(j<0 || j>5) return;
     faoq[j] = aoq;
     fzet[j] = zet;
+  }
+  //! Set the Z number
+  void SetZdeg(unsigned short j, double zet){
+    if(j<0 || j>1) return;
+    fzdeg[j] = zet;
+  }
+  //! Set corrected Zdeg
+  void SetCorrZdeg(unsigned short j, double zet){
+    if(j<0 || j>1) return;
+    fzdegc[j] = zet;
   }
   //! Set the time-of-flight
   void SetTOF(unsigned short j, double tof){    
@@ -196,6 +210,16 @@ public:
     if(j<0 || j>5) return sqrt(-1.);
     return fzet[j];
   }
+  //! Get the Z number
+  double GetZdeg(unsigned short j){
+    if(j<0 || j>1) return sqrt(-1.);
+    return fzdeg[j];
+  }
+  //! Get the corrected Z number
+  double GetCorrZdeg(unsigned short j){
+    if(j<0 || j>1) return sqrt(-1.);
+    return fzdegc[j];
+  }
   //! Get the time-of-flight
   double GetTOF(unsigned short j){
     if(j<0 || j>2) return sqrt(-1.);
@@ -300,6 +324,8 @@ protected:
   double fzet[6];
   //! corrected Z
   double fzetc[6];
+  //! corrected Z
+  double fzdeg[2], fzdegc[2];
 
   //! time-of-flight for 3-7, 8-11, 7-8
   double ftof[3];

--- a/inc/FocalPlane.hh
+++ b/inc/FocalPlane.hh
@@ -109,47 +109,105 @@ public:
     ftimeR = sqrt(-1.);
     fchargeL = sqrt(-1.);
     fchargeR = sqrt(-1.);
+    fmultL = 0;
+    fmultR = 0;
+    fqtctime = sqrt(-1.);
+    fqtccharge = sqrt(-1.);
+    fqtctimeL = sqrt(-1.);
+    fqtctimeR = sqrt(-1.);
+    fqtcchargeL = sqrt(-1.);
+    fqtcchargeR = sqrt(-1.);
   }
   //! Set the time
-  void SetTime(Float_t timeL, Float_t timeR){
+  void SetTime(Double_t timeL, Double_t timeR){
     ftimeL = timeL;
     ftimeR = timeR;
     if( !isnan(timeL) && !isnan(timeR))
       ftime = (timeL + timeR)/2;
   }
   //! Set the charge
-  void SetCharge(double chargeL, double chargeR){
-    fchargeL = chargeL;
-    fchargeR = chargeR;
+  void SetCharge(Int_t chargeL, Int_t chargeR){
+    fchargeL = (Float_t) chargeL;
+    fchargeR = (Float_t) chargeR;
     fcharge = sqrt(chargeL * chargeR);
   }
+  //! Set the multiplicity within the time window
+  void SetMult(Int_t multL, Int_t multR){
+    fmultL = multL;
+    fmultR = multR;
+  }
+  //! Set the time
+  void SetQTCTime(Int_t qtctimeL, Int_t qtctimeR){
+    if(qtctimeL>0) fqtctimeL = (Double_t)qtctimeL;
+    if(qtctimeR>0) fqtctimeR = (Double_t)qtctimeR;
+    if( !isnan(fqtctimeL) && !isnan(fqtctimeR))
+      fqtctime = (fqtctimeL + fqtctimeR)/2.;
+  }
+  //! Set the qtccharge
+  void SetQTCCharge(Int_t qtcchargeL, Int_t qtcchargeR){
+    if(qtcchargeL>0) fqtcchargeL = (Double_t)qtcchargeL;
+    if(qtcchargeR>0) fqtcchargeR = (Double_t)qtcchargeR;
+    if( !isnan(fqtcchargeL) && !isnan(fqtcchargeR))
+      fqtccharge  = sqrt(fqtcchargeL * fqtcchargeR);
+  }
   //! Get the time
-  double GetTime(){return ftime;}
+  Double_t GetTime(){return ftime;}
   //! Get the charge
-  double GetCharge(){return fcharge;}
+  Double_t GetCharge(){return fcharge;}
   //! Get the time left
-  double GetTimeL(){return ftimeL;}
+  Double_t GetTimeL(){return ftimeL;}
   //! Get the charge left
-  double GetChargeL(){return fchargeL;}
+  Double_t GetChargeL(){return fchargeL;}
+  //! Get the mult left
+  Int_t    GetMultL(){return fmultL;}
   //! Get the time right
-  double GetTimeR(){return ftimeR;}
+  Double_t GetTimeR(){return ftimeR;}
   //! Get the charge right
-  double GetChargeR(){return fchargeR;}
+  Double_t GetChargeR(){return fchargeR;}
+  //! Get the mult right
+  Int_t    GetMultR(){return fmultR;}
+  //! Get the time
+  Double_t GetQTCTime(){return fqtctime;}
+  //! Gett the charge
+  Double_t GettQTCCharge(){return fqtccharge;}
+  //! Get the time lefqtct
+  Double_t GettQTCTimeL(){return fqtctimeL;}
+  //! Get the charge lefqtct
+  Double_t GettQTCChargeL(){return fqtcchargeL;}
+  //! Get the time right
+  Double_t GettQTCTimeR(){return fqtctimeR;}
+  //! Get the charge right
+  Double_t GettQTCChargeR(){return fqtcchargeR;}
   
 protected:
   //! timing of the plastic (TL + TR)
-  Float_t ftime;
+  Double_t ftime;
   //! charge deposit in the plastic (sqrt(QL*QR))
   Float_t fcharge;
   //! timing of left PMT
-  Float_t ftimeL;
+  Double_t ftimeL;
   //! timing of right PMT
-  Float_t ftimeR;
+  Double_t ftimeR;
   //! charge of left PMT
   Float_t fchargeL;
   //! charge of right PMT
   Float_t fchargeR;
-
+  //! multiplicity of left PMT
+  Int_t fmultL;
+  //! multiplicity of right PMT
+  Int_t fmultR;
+  //! timing of the plastic (TL + TR) with QTC
+  Double_t fqtctime;
+  //! charge deposit in the plastic ((QL+QR)/2) with QTC
+  Double_t fqtccharge;
+  //! timing of left PMT with QTC
+  Double_t fqtctimeL;
+  //! timing of right PMT with QTC
+  Double_t fqtctimeR;
+  //! charge of left PMT with QTC
+  Double_t fqtcchargeL;
+  //! charge of right PMT with QTC
+  Double_t fqtcchargeR;
   /// \cond CLASSIMP
   ClassDef(Plastic,1);
   /// \endcond
@@ -235,6 +293,10 @@ public:
   void SetPlastic(Plastic plastic){fplastic = plastic;}
   //! return the plastic
   Plastic* GetPlastic(){return &fplastic;}
+  //! set the plastic2
+  void SetPlastic2(Plastic plastic2){fplastic2 = plastic2;}
+  //! return the plastic2
+  Plastic* GetPlastic2(){return &fplastic2;}
   //! set the music
   void SetMUSIC(MUSIC music){fmusic = music;}
   //! return the music
@@ -245,6 +307,7 @@ protected:
   Track ftrack;
   //! Plastic for that focal plane
   Plastic fplastic;
+  Plastic fplastic2;
   //! Ionchamber for that focal plane
   MUSIC fmusic;
 

--- a/inc/Settings.hh
+++ b/inc/Settings.hh
@@ -158,6 +158,16 @@ public:
   double GetBRAoQCorrection_offs(){return faoq_lin[0][1];}
   double GetZDAoQCorrection_gain(){return faoq_lin[1][0];}
   double GetZDAoQCorrection_offs(){return faoq_lin[1][1];}
+
+  double GetBRZdegCorrection_F5X(){return fzdeg_corr[0][0];}
+  double GetBRZdegCorrection_F5A(){return fzdeg_corr[0][1];}
+  double GetZDZdegCorrection_F9X(){return fzdeg_corr[1][0];}
+  double GetZDZdegCorrection_F9A(){return fzdeg_corr[1][1];}
+
+  double GetBRZdeg_gain(){return fzdeg_coef[0][0];}
+  double GetBRZdeg_offs(){return fzdeg_coef[0][1];}
+  double GetZDZdeg_gain(){return fzdeg_coef[1][0];}
+  double GetZDZdeg_offs(){return fzdeg_coef[1][1];}
 protected:
   int fEventTimeDiff;
   vector<string> fInputFiles;
@@ -243,6 +253,8 @@ protected:
   double faoq_corr[2][3][3];  // BR/ZD, focal plane, x,angle,q
 
   double faoq_lin[2][2]; // BR/ZD, gain,off
+
+  double fzdeg_corr[2][2], fzdeg_coef[2][2];
 
   ClassDef(Settings, 1)
 };

--- a/src/Settings.cc
+++ b/src/Settings.cc
@@ -118,6 +118,18 @@ void Settings::ReadSettings(TEnv* set){
   faoq_lin[1][0] = set->GetValue("ZeroDeg.AoQCorr_Gain",1.0);
   faoq_lin[1][1] = set->GetValue("ZeroDeg.AoQCorr_Offs",0.0);
 
+  fzdeg_corr[0][0] = set->GetValue("BigRIPS.ZdegCorr_F5X",0.0);
+  fzdeg_corr[0][1] = set->GetValue("BigRIPS.ZdegCorr_F5A",0.0);
+
+  fzdeg_corr[1][0] = set->GetValue("ZeroDeg.ZdegCorr_F9X",0.0);
+  fzdeg_corr[1][1] = set->GetValue("ZeroDeg.ZdegCorr_F9A",0.0);
+
+  fzdeg_coef[0][0] = set->GetValue("BigRIPS.Zdeg_Gain",1.0);
+  fzdeg_coef[0][1] = set->GetValue("BigRIPS.Zdeg_Offs",0.0);
+
+  fzdeg_coef[1][0] = set->GetValue("ZeroDeg.Zdeg_Gain",1.0);
+  fzdeg_coef[1][1] = set->GetValue("ZeroDeg.Zdeg_Offs",0.0);
+
 }
 
 /*
@@ -217,6 +229,10 @@ void Settings::PrintSettings(){
   cout << "ZeroDeg.AoQCorr_F11X\t" << faoq_corr[1][2][0] << endl;  
   cout << "ZeroDeg.AoQCorr_F11A\t" << faoq_corr[1][2][1] << endl;  
 
+  cout << "BigRIPS.ZdegCorr_F5X\t" << fzdeg_corr[0][0] << endl;
+  cout << "BigRIPS.ZdegCorr_F5A\t" << fzdeg_corr[0][1] << endl;
+  cout << "ZeroDeg.ZdegCorr_F9X\t" << fzdeg_corr[1][0] << endl;
+  cout << "ZeroDeg.ZdegCorr_F9A\t" << fzdeg_corr[1][1] << endl;
 
 }
 void Settings::ReadHiCARIMappingTable(){


### PR DESCRIPTION
…rgy loss of the degrader at F5 will be calculated from the difference in reconstructed energes of F3-F5 and F5-F7 from the momentum (Brho) measurements. To accommodate correction of the effective thickness of the degrader w.r.t the position and angle, coefficients can be set from setting files.

The measurement with the QTC (charge-to-time converter) module can also be obtained for the reconstruction of the charge of the plastic detector and the elimination of pile-up events mostly at F3 due to light ion hits. The multiplicity of the plastic detectors are also able to be obtained to flag possibly pile-up events in MUSIC detectors.
To include the F11-long plastic in addition to the F11-1 one, a second plastic is included in each focal plane.
As the time information from the CAEN's TDC module ranges in a rather similar order of magnitude as the accuracy of the float type, the measured TDC values and the reconstructed times are stored in the Double_t type.